### PR TITLE
Option to import created image directly into local docker registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.5.0] - TBD
+
+### Added
+
+- Option to import created image directly into local docker registry
+
 ## [2.4.0] - 2023-06-21
 
 - Internal refactoring

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "containerify",
-	"version": "2.4.0",
+	"version": "2.5.0",
 	"description": "Build node.js docker images without docker",
 	"main": "./lib/cli.js",
 	"scripts": {

--- a/src/dockerExporter.ts
+++ b/src/dockerExporter.ts
@@ -1,0 +1,25 @@
+import { promisify } from "node:util";
+import { exec } from "node:child_process";
+
+import logger from "./logger";
+
+const execAsync = promisify(exec);
+
+async function isAvailable() {
+	try {
+		await execAsync("docker -v");
+	} catch (e) {
+		return false;
+	}
+	return true;
+}
+
+async function load(path: string) {
+	logger.info("Loading docker image from tarball...");
+	await execAsync(`docker load -i ${path}`);
+}
+
+export default {
+	isAvailable,
+	load,
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,7 @@ export type Options = {
 	toRegistry?: string;
 	toToken?: string;
 	toTar?: string;
+	toDocker?: boolean;
 	registry?: string;
 	platform: string;
 	token?: string;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "2.4.0";
+export const VERSION = "2.5.0";


### PR DESCRIPTION
Quick and dirty Docker-integration using `docker` commands to import the tarball created by the tarExporter.

Resolves #18 