### PR TITLE
Entrypoint, workdir and user layers when using customContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.5.1] - TBD
+
+### Fixed
+
+- Layers for `ENTRYPOINT`, `WORKDIR` and user information are now being added when using `customContent`
+
 ## [2.5.0] - TBD
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "containerify",
-	"version": "2.5.0",
+	"version": "2.5.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "containerify",
-			"version": "2.5.0",
+			"version": "2.5.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"commander": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "containerify",
-	"version": "2.5.0",
+	"version": "2.5.1",
 	"description": "Build node.js docker images without docker",
 	"main": "./lib/cli.js",
 	"scripts": {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "2.5.0";
+export const VERSION = "2.5.1";

--- a/tests/integration/file/containerify.json
+++ b/tests/integration/file/containerify.json
@@ -1,0 +1,8 @@
+{
+  "fromImage": "node:alpine",
+  "toImage": "containerify:demo-app",
+  "folder": ".",
+  "customContent": [
+    "customContent"
+  ]
+}

--- a/tests/integration/test.sh
+++ b/tests/integration/test.sh
@@ -9,6 +9,7 @@ rm -rf tmp
 mkdir -p tmp/v1/content/
 mkdir -p tmp/v2/content/
 mkdir -p tmp/v3/content/
+mkdir -p tmp/v4/content/
 mkdir -p tmp/layercache
 
 echo "Building image 1..."
@@ -23,11 +24,15 @@ echo "Building image 3..."
 
 ../../lib/cli.js --fromImage node:alpine --toImage containerify:demo-app --folder . --toTar tmp/v3.tar --customContent customContent --setTimeStamp "2023-03-07T12:53:10.471Z" --layerCacheFolder tmp/layercache > /dev/null
 
+echo "Building image 4..."
+
+../../lib/cli.js --file ./file/containerify.json --toTar tmp/v4.tar --setTimeStamp "2023-03-07T12:53:10.471Z" --layerCacheFolder tmp/layercache > /dev/null
 
 echo "Untaring content ..."
 tar -xf tmp/v1.tar -C tmp/v1/content/
 tar -xf tmp/v2.tar -C tmp/v2/content/
 tar -xf tmp/v3.tar -C tmp/v3/content/
+tar -xf tmp/v4.tar -C tmp/v4/content/
 
 jqscript='if (.config.Entrypoint == ["npm", "start"]) then true else false end'
 
@@ -56,7 +61,7 @@ if ! cmp -s tmp/v1/content/manifest.json tmp/v2/content/manifest.json; then
 fi
 
 echo "Checking that config files for 1 and 3 are not equal ..."
-if cmp -s tmp/v1/content/config.json tmp/v3/content/maniconfigfest.json; then
+if cmp -s tmp/v1/content/config.json tmp/v3/content/config.json; then
    echo "ERROR: config.jsons are the same"; 
    exit 1;
 fi
@@ -64,6 +69,18 @@ fi
 echo "Checking that manifest files for 1 and 3 are not equal ..."
 if cmp -s tmp/v1/content/manifest.json tmp/v3/content/manifest.json; then
    echo "ERROR: manifest.jsons are the same"; 
+   exit 1;
+fi
+
+echo "Checking that config files for 3 and 4 are equal ..."
+if ! cmp -s tmp/v3/content/config.json tmp/v4/content/config.json; then
+   echo "ERROR: config.jsons are not the same";
+   exit 1;
+fi
+
+echo "Checking that manifest files for 3 and 4 are equal ..."
+if ! cmp -s tmp/v3/content/manifest.json tmp/v4/content/manifest.json; then
+   echo "ERROR: manifest.jsons are not the same";
    exit 1;
 fi
 

--- a/tests/integration/test.sh
+++ b/tests/integration/test.sh
@@ -29,6 +29,20 @@ tar -xf tmp/v1.tar -C tmp/v1/content/
 tar -xf tmp/v2.tar -C tmp/v2/content/
 tar -xf tmp/v3.tar -C tmp/v3/content/
 
+jqscript='if (.config.Entrypoint == ["npm", "start"]) then true else false end'
+
+echo "Checking that entrypoint is correctly set for 1 ..."
+if [[ $(cat tmp/v1/content/config.json | jq "$jqscript") != "true" ]]; then
+  echo "ERROR: wrong entrypoint set";
+  exit 1;
+fi
+
+echo "Checking that entrypoint is correctly set for 3 ..."
+if [[ $(cat tmp/v3/content/config.json | jq "$jqscript") != "true" ]]; then
+  echo "ERROR: wrong entrypoint set";
+  exit 1;
+fi
+
 echo "Checking that config files for 1 and 2 are equal ..."
 if ! cmp -s tmp/v1/content/config.json tmp/v2/content/config.json; then
    echo "ERROR: config.jsons are different"; 


### PR DESCRIPTION
Entrypoint, workdir and user layers were not being created when using customContent.

Looking at the changelog this seems  to be a deliberate decision (v0.1.0), but it leaves no option to change them at all.

I'm proposing a solution where we use the default values for these layers, but I'm open to other solutions.