### PR TITLE
Handling redirects when checking for existing layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.6.1] - 2023-11-12
+
+### Added
+
+- Option for optimistic remote registry cache checking. i.e. treat redirects as layer existing
+
+### Fixed
+
+- Follow redirects when checking for existing layers in remote registry
+
+
 ## [2.6.0] - 2023-10-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Options:
   --fromRegistry <registry url>  Optional: URL of registry to pull base image from - Default: https://registry-1.docker.io/v2/
   --fromToken <token>            Optional: Authentication token for from registry
   --toRegistry <registry url>    Optional: URL of registry to push base image to - Default: https://registry-1.docker.io/v2/
+  --optimisticToRegistryCheck    Optional: Treat redirects as layer existing in remote registry. Potentially unsafe, but could save bandwidth.
   --toToken <token>              Optional: Authentication token for target registry
   --toTar <path>                 Optional: Export to tar file
   --registry <path>              Optional: Convenience argument for setting both from and to registry

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "containerify",
-	"version": "2.6.0",
+	"version": "2.6.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "containerify",
-			"version": "2.6.0",
+			"version": "2.6.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"commander": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "containerify",
-	"version": "2.6.0",
+	"version": "2.6.1",
 	"description": "Build node.js docker images without docker",
 	"main": "./lib/cli.js",
 	"scripts": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,7 @@ const possibleArgs = {
 	"--fromToken <token>": "Optional: Authentication token for from registry",
 	"--toRegistry <registry url>":
 		"Optional: URL of registry to push base image to - Default: https://registry-1.docker.io/v2/",
+	"--optimisticToRegistryCheck": "Treat redirects as layer existing in remote registry. Potentially unsafe, but can save bandwidth.",
 	"--toToken <token>": "Optional: Authentication token for target registry",
 	"--toTar <path>": "Optional: Export to tar file",
 	"--toDocker": "Optional: Export to local docker registry",
@@ -278,7 +279,7 @@ async function run(options: Options) {
 		await tarExporter.saveToTar(todir, tmpdir, options.toTar, [options.toImage], options);
 	}
 	if (options.toRegistry) {
-		const toRegistry = createRegistry(options.toRegistry, options.toToken ?? "");
+		const toRegistry = createRegistry(options.toRegistry, options.toToken ?? "", options.optimisticToRegistryCheck);
 		await toRegistry.upload(options.toImage, todir);
 	}
 	logger.debug("Deleting " + tmpdir + " ...");

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,7 @@ export type Options = {
 	fromRegistry?: string;
 	fromToken?: string;
 	toRegistry?: string;
+	optimisticToRegistryCheck?: boolean;
 	toToken?: string;
 	toTar?: string;
 	toDocker?: boolean;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "2.6.0";
+export const VERSION = "2.6.1";


### PR DESCRIPTION
Trying to use `containerify` with GitLab Container Registry I get 307 redirects when checking for existing layers.
These redirects are handled as errors, thus failing the upload. I tried following the redirects, but end up getting 401-errors for most of them.

I see four solutions to this.
1) Treat redirects as the layer not existing
2) Follow redirects and treat all non-200 codes as the layer not existing
3) Follow redirects and treat 401 as the layer existing
4) Trust that redirects means the layer exists

1 and 2 would be the safest options, but would also use unnecessary bandwidth. 3 would be a bit safer, but also maybe unnecessary. 4 would save on bandwidth, but could be unsafe. 

I personally prefer 4, choosing to trust the GitLab infrastructure. I've tested that this works.

This [issue](https://gitlab.com/gitlab-org/gitlab/-/issues/23132) about registry layers not being shared might be related.

Looking at an excerpt from the logs it looks like GitLab saves the layers on a CDN we probably can't access from the pipeline.
```
2023-11-11T19:33:36.187Z DEBUG HEAD https://registry.gitlab.com/v2/.../blobs/sha256:71dd... 307
2023-11-11T19:33:36.187Z DEBUG HEAD https://cdn.registry.gitlab-static.net/gitlab/docker/registry/v2/blobs/sha256/71/71ed.../data?Expires=1699732416&KeyName=gprd-registry-cdn&Signature=kBYX...
2023-11-11T19:33:36.188Z DEBUG HEAD https://registry.gitlab.com/v2/.../blobs/sha256:f79d... 307
2023-11-11T19:33:36.188Z DEBUG HEAD https://cdn.registry.gitlab-static.net/gitlab/docker/registry/v2/blobs/sha256/f7/f79f.../data?Expires=1699732416&KeyName=gprd-registry-cdn&Signature=3me...
2023-11-11T19:33:36.271Z DEBUG HEAD https://cdn.registry.gitlab-static.net/gitlab/docker/registry/v2/blobs/sha256/96/965d.../data?Expires=1699732416&KeyName=gprd-registry-cdn&Signature=kPk... 200
2023-11-11T19:33:36.391Z DEBUG HEAD https://cdn.registry.gitlab-static.net/gitlab/docker/registry/v2/blobs/sha256/27/277e.../data?Expires=1699732416&KeyName=gprd-registry-cdn&Signature=XCB... 401
```

To reproduce run the following pipeline-script in a GitLab project with a container registry and use the short-lived token to push to the registry

```yaml
build:
  stage: build
  script:
    # https://docs.gitlab.com/ee/api/container_registry.html#obtain-token-from-gitlab
    - CI_USER_CREDS="${CI_REGISTRY_USER}:${CI_REGISTRY_PASSWORD}"
    - SCOPE="repository:${CI_PROJECT_NAMESPACE}/${CI_PROJECT_NAME}:pull,push"
    - AUTH_URL="${CI_SERVER_URL}/jwt/auth?service=container_registry&scope=${SCOPE}"
    - TOKEN=$(curl -sL --user "${CI_USER_CREDS}" "${AUTH_URL}" | sed 's/.*"token":"\{0,1\}\([^,"]*\)"\{0,1\}.*/\1/')
    - echo $TOKEN
```