### PR TITLE
fix: Allow pushing to insecure registries without a token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.0.2] - 2024-01-18
+
+### Fixed
+
+- Allow pushing to insecure registries without a token
+
 ## [3.0.1] - 2024-01-18
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "containerify",
-	"version": "3.0.1",
+	"version": "3.0.2",
 	"description": "Build node.js docker images without docker",
 	"main": "./lib/cli.js",
 	"scripts": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -242,7 +242,6 @@ exitWithErrorIf(
 	!options.toRegistry && !options.toTar && !options.toDocker,
 	"Must specify either --toTar, --toRegistry or --toDocker",
 );
-exitWithErrorIf(!!options.toRegistry && !options.toToken, "A token must be given when uploading to docker hub");
 
 if (options.toRegistry && !options.toRegistry.endsWith("/")) options.toRegistry += "/";
 if (options.fromRegistry && !options.fromRegistry.endsWith("/")) options.fromRegistry += "/";

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -126,11 +126,9 @@ function uploadContent(
 		logger.debug("Uploading: ", file);
 		let url = uploadUrl;
 		if (fileConfig.digest) url += (url.indexOf("?") == -1 ? "?" : "&") + "digest=" + fileConfig.digest;
-		const options = createHttpOptions("PUT", url, {
-			authorization: auth,
-			"content-length": fileConfig.size,
-			"content-type": contentType,
-		});
+		const headers: OutgoingHttpHeaders = { "content-length": fileConfig.size, "content-type": contentType};
+		if (auth) headers.authorization = auth;
+		const options = createHttpOptions("PUT", url, headers);
 		logger.debug(options.method, url);
 		const req = request(options, allowInsecure, (res) => {
 			logger.debug(res.statusCode, res.statusMessage, res.headers["content-type"], res.headers["content-length"]);
@@ -222,7 +220,7 @@ export async function createRegistry(
 			const url = `${registryBaseUrl}${image.path}/blobs/uploads/${parameters.size > 0 ? "?" + parameters : ""}`;
 			const options: https.RequestOptions = URL.parse(url);
 			options.method = "POST";
-			options.headers = { authorization: auth };
+			if (auth) options.headers = { authorization: auth };
 			request(options, allowInsecure, (res) => {
 				logger.debug("POST", `${url}`, res.statusCode);
 				if (res.statusCode == 202) {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "3.0.1";
+export const VERSION = "3.0.2";

--- a/tests/localtest/test-insecure.sh
+++ b/tests/localtest/test-insecure.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -e
+
+export DOCKER_CONFIG=tmp
+LOCAL_REGISTRY=127.0.0.1
+
+rm -rf tmp
+mkdir tmp
+
+printf "* Stopping any running local containerify test registry...\n"
+docker stop registry-containerify-insecure-test >/dev/null 2>&1 || echo "No running container registry, so nothing to stop"
+
+printf "* Starting local containerify test registry on port 5443...\n"
+docker run -d \
+  --rm \
+  --name registry-containerify-insecure-test \
+  -e REGISTRY_HTTP_ADDR=0.0.0.0:5443 \
+  -p 5443:5443 \
+  registry:2 > /dev/null
+
+printf "* Pulling node:alpine as base image...\n"
+docker pull node:alpine  &>  /dev/null
+
+printf "* Pushing base image to local containerify test registry...\n"
+docker tag node:alpine ${LOCAL_REGISTRY}:5443/node > /dev/null
+docker push ${LOCAL_REGISTRY}:5443/node > /dev/null
+
+printf "* Running containerify to pull from and push result to the local containerify test registry...\n"
+cd ../integration/app
+npm ci
+cd ../../localtest
+../../lib/cli.js --registry http://${LOCAL_REGISTRY}:5443/v2/ \
+                 --fromImage node \
+                 --toImage containerify-integration-test:localtest \
+                 --allowInsecureRegistries --doCrossMount \
+                 --folder ../integration/app --setTimeStamp "2024-01-18T13:33:33.337Z"
+
+printf "\n* Pulling image from registry to local docker daemon...\n"
+docker pull ${LOCAL_REGISTRY}:5443/containerify-integration-test:localtest &> /dev/null
+
+printf "* Running image on local docker daemon...\n"
+docker run --rm -it ${LOCAL_REGISTRY}:5443/containerify-integration-test:localtest
+
+printf "\n* Deleting image from registry to local docker daemon...\n"
+docker rmi ${LOCAL_REGISTRY}:5443/containerify-integration-test:localtest > /dev/null
+
+printf "* Stopping local containerify test registry...\n"
+docker stop registry-containerify-insecure-test > /dev/null
+rm -rf tmp
+
+printf "\nSUCCESS!\n"

--- a/tests/localtest/test.sh
+++ b/tests/localtest/test.sh
@@ -56,8 +56,7 @@ printf "* Running containerify to pull from and push result to the local contain
 cd ../integration/app
 npm ci
 cd ../../localtest
-../../lib/cli.js --registry https://${LOCAL_REGISTRY}:5443/v2/ \
-                 --allowInsecureRegistries \
+NODE_TLS_REJECT_UNAUTHORIZED=0 ../../lib/cli.js --registry https://${LOCAL_REGISTRY}:5443/v2/ \
                  --token "Basic $BASICAUTH" \
                  --fromImage node \
                  --toImage containerify-integration-test:localtest \

--- a/tests/localtest/test.sh
+++ b/tests/localtest/test.sh
@@ -54,9 +54,15 @@ docker push ${LOCAL_REGISTRY}:5443/node > /dev/null
 
 printf "* Running containerify to pull from and push result to the local containerify test registry...\n"
 cd ../integration/app
-npm install
+npm ci
 cd ../../localtest
-../../lib/cli.js --fromImage node --doCrossMount --registry https://${LOCAL_REGISTRY}:5443/v2/ --toImage containerify-integration-test:localtest --folder ../integration/app --setTimeStamp "2023-03-07T12:53:10.471Z" --allowInsecureRegistries --token "Basic $BASICAUTH"
+../../lib/cli.js --registry https://${LOCAL_REGISTRY}:5443/v2/ \
+                 --allowInsecureRegistries \
+                 --token "Basic $BASICAUTH" \
+                 --fromImage node \
+                 --toImage containerify-integration-test:localtest \
+                 --doCrossMount \
+                 --folder ../integration/app --setTimeStamp "2023-03-07T12:53:10.471Z"
 
 
 printf "\n* Pulling image from registry to local docker daemon...\n"


### PR DESCRIPTION
Remove token check when pushing images to allow pushing to open/insecure registries. Pushing to secure registries without a token should be stopped by the registry itself.