### PR TITLE
fix: Use processed token when getting upload URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.1.1] - 2024-01-28
+
+### Fixed
+
+- Use processed token instead of raw supplied auth to get upload URL
+
 ## [3.1.0] - 2024-01-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This will take the `nginx:alpine` image, and copy the files from `./dist/` into 
 
 1. Create the repository in GitLab
 2. Login using your username and password, [CI-credentials](https://docs.gitlab.com/ee/ci/jobs/ci_job_token.html), or [obtain a token from GitLab](https://docs.gitlab.com/ee/api/container_registry.html#obtain-token-from-gitlab)
-3. Example using CI-credentials `containerify --toToken "Basic $(echo -n '${CI_REGISTRY_USER}:${CI_REGISTRY_PASSWORD}' | base64)" --to registry.gitlab.com/<Gitlab organisation>/<repository>:<tag>`
+3. Example using CI-credentials `containerify --toToken "Basic $(echo -n "${CI_REGISTRY_USER}:${CI_REGISTRY_PASSWORD}" | base64)" --to registry.gitlab.com/<Gitlab organisation>/<repository>:<tag>`
 
 ### Command line options
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "containerify",
-	"version": "3.1.0",
+	"version": "3.1.1",
 	"description": "Build node.js docker images without docker",
 	"main": "./lib/cli.js",
 	"scripts": {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "3.1.0";
+export const VERSION = "3.1.1";


### PR DESCRIPTION
Using raw supplied auth when getting the upload URL fails with e.g. GitLab when we need to process the authentication to get a valid token.