### PR TITLE
Support more GitHub tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## [3.2.0] - 2025-03-07
+## [3.2.0] - 2025-03-19
 
 ### Added
 
 - Option to preserve original timestamps
+
+### Fixed
+
+- Automatically base64 encode more GitHub token types
 
 ## [3.1.2] - 2025-02-10
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -165,7 +165,8 @@ async function processToken(
 	if (hostname?.endsWith(".gitlab.com") && token.startsWith("Basic "))
 		return getGitLabToken(token, image.path, allowInsecure);
 	if (token.startsWith("Basic ")) return token;
-	if (token.startsWith("ghp_")) return "Bearer " + Buffer.from(token).toString("base64");
+	const githubPrefixes = ["ghp_", "github_pat_", "gho_", "ghu_", "ghs_"];
+	if (githubPrefixes.some((prefix) => token.startsWith(prefix))) return "Bearer " + Buffer.from(token).toString("base64");
 	return "Bearer " + token;
 }
 


### PR DESCRIPTION
Automatically base64 encode more GitHub token types

https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github#githubs-token-formats